### PR TITLE
Added sticker install support for code server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.1 [Code Server Support]
+
+- Stickers/background can be installed on VSCode running on Code Server.
+
 ## 2.0.0 [New Themes!]
 
 - Added 5 new themes based on various new characters!

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "Themes based on various anime and visual novel characters.",
   "publisher": "unthrottled",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -8,8 +8,16 @@ export enum InstallStatus {
 
 const main = require.main || { filename: 'yeet' };
 export const workbenchDirectory = path.join(path.dirname(main.filename), 'vs', 'workbench');
-const editorCss = path.join(workbenchDirectory, 'workbench.desktop.main.css');
-const editorCssCopy = path.join(workbenchDirectory, 'workbench.desktop.main.css.copy');
+
+const getFileName = () => {
+  return fs.existsSync(path.join(workbenchDirectory, `workbench.desktop.main.css`)) ?
+   'desktop.main' : 'web.api';
+};
+
+const fileName = getFileName();
+
+const editorCss = path.join(workbenchDirectory, `workbench.${fileName}.css`);
+const editorCssCopy = path.join(workbenchDirectory, `workbench.${fileName}.css.copy`);
 
 // Was VS Code upgraded when stickers where installed?
 function isCssPrestine() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Added the ability to modify the server css or desktop css depending on install.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
So apparently VSCode can run as a desktop app **and** as a server app.
https://github.com/microsoft/vscode/tree/master/src/vs/workbench

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on my local code server.

#### Screenshots (if appropriate):
Screen cast of me fumbling through usage:
https://vimeo.com/401866027

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.