### PR TITLE
Dynamic Stickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.2 [Non-Functional]
+
+- Changed how the plugin gets stickers. 
+    - I am now able to update the stickers without you having to download a new version.
+
+
 ## 2.0.1 [Code Server Support]
 
 - Stickers/background can be installed on VSCode running on Code Server.

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -482,7 +482,7 @@ walkDir(templateDirectoryPath)
       }
     };
   });
-  const finalDokiDefinitions = JSON.stringify(dokiThemeDefinitions, null, 2);
+  const finalDokiDefinitions = JSON.stringify(dokiThemeDefinitions);
   fs.writeFileSync(
     path.resolve(repoDirectory, 'src', 'DokiThemeDefinitions.ts'),
     `export default ${finalDokiDefinitions};`);

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -373,7 +373,7 @@ function resolveStickerPath(
     path.resolve(themeDefinitonPath, '..'),
     themeDefinition.stickers.normal || themeDefinition.stickers.default
   );
-  return stickerPath.substring(vsCodeDefinitionDirectoryPath.length);
+  return stickerPath.substring(vsCodeDefinitionDirectoryPath.length).replace(/\\/g, '/');
 }
 
 function getThemeGroup(dokiDefinition: MasterDokiThemeDefinition) {

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -365,9 +365,7 @@ const readTemplates = (templatePaths: string[]): TemplateTypes => {
     });
 };
 
-const base64Img = require('base64-img');
-
-function readSticker(
+function resolveStickerPath(
   themeDefinitonPath: string,
   themeDefinition: MasterDokiThemeDefinition,
 ) {
@@ -375,7 +373,7 @@ function readSticker(
     path.resolve(themeDefinitonPath, '..'),
     themeDefinition.stickers.normal || themeDefinition.stickers.default
   );
-  return base64Img.base64Sync(stickerPath);
+  return stickerPath.substring(vsCodeDefinitionDirectoryPath.length);
 }
 
 function getThemeGroup(dokiDefinition: MasterDokiThemeDefinition) {
@@ -475,7 +473,7 @@ walkDir(templateDirectoryPath)
           'icons'
         ]),
         sticker: {
-          url: readSticker(
+          path: resolveStickerPath(
             dokiTheme.path,
             dokiDefinition
           ),
@@ -484,7 +482,7 @@ walkDir(templateDirectoryPath)
       }
     };
   });
-  const finalDokiDefinitions = JSON.stringify(dokiThemeDefinitions);
+  const finalDokiDefinitions = JSON.stringify(dokiThemeDefinitions, null, 2);
   fs.writeFileSync(
     path.resolve(repoDirectory, 'src', 'DokiThemeDefinitions.ts'),
     `export default ${finalDokiDefinitions};`);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "Themes based on various anime and visual novel characters.",
   "publisher": "unthrottled",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/DokiTheme.ts
+++ b/src/DokiTheme.ts
@@ -11,7 +11,7 @@ export class DokiTheme {
     this.displayName = dokiThemeDefinition.information.displayName;
     this.id = dokiThemeDefinition.information.id;
     this.sticker = {
-      url: dokiThemeDefinition.sticker.url,
+      url: dokiThemeDefinition.sticker.path,
       name: dokiThemeDefinition.sticker.name
     };
   }

--- a/src/DokiTheme.ts
+++ b/src/DokiTheme.ts
@@ -11,13 +11,13 @@ export class DokiTheme {
     this.displayName = dokiThemeDefinition.information.displayName;
     this.id = dokiThemeDefinition.information.id;
     this.sticker = {
-      url: dokiThemeDefinition.sticker.path,
+      path: dokiThemeDefinition.sticker.path,
       name: dokiThemeDefinition.sticker.name
     };
   }
 }
 
 export interface Sticker {
-  url: string;
+  path: string;
   name: string;
 }

--- a/src/DokiTheme.ts
+++ b/src/DokiTheme.ts
@@ -4,10 +4,12 @@ export class DokiTheme {
   name: string;
   displayName: string;
   sticker: Sticker;
+  id: string;
 
   constructor(dokiThemeDefinition: DokiThemeDefinition) {
     this.name = dokiThemeDefinition.information.name;
     this.displayName = dokiThemeDefinition.information.displayName;
+    this.id = dokiThemeDefinition.information.id;
     this.sticker = {
       url: dokiThemeDefinition.sticker.url,
       name: dokiThemeDefinition.sticker.name

--- a/src/ENV.ts
+++ b/src/ENV.ts
@@ -1,0 +1,5 @@
+
+export const ASSETS_URL = `https://doki.assets.unthrottled.io`;
+export const VSCODE_ASSETS_URL = `${ASSETS_URL}/stickers/vscode`;
+export const BACKGROUND_ASSETS_URL = `${ASSETS_URL}/backgrounds`;
+export const SCREENSHOT_ASSETS_URL = `${ASSETS_URL}/screenshots`;

--- a/src/ENV.ts
+++ b/src/ENV.ts
@@ -1,4 +1,3 @@
-
 export const ASSETS_URL = `https://doki.assets.unthrottled.io`;
 export const VSCODE_ASSETS_URL = `${ASSETS_URL}/stickers/vscode`;
 export const BACKGROUND_ASSETS_URL = `${ASSETS_URL}/backgrounds`;

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from './VSCodeGlobals';
 import { attemptToGreetUser } from './WelcomeService';
 
 const SAVED_VERSION = 'doki.theme.version';
-const DOKI_THEME_VERSION = 'v2.0.0';
+const DOKI_THEME_VERSION = 'v2.0.2';
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
     const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -1,0 +1,18 @@
+import https from 'https';
+import { Transform as Stream } from 'stream';
+
+export const performGet = (url: string): Promise<Stream> => {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      const inputStream = new Stream();
+      res.on('data', (d) => {
+        inputStream.push(d);
+      });
+      res.on('end', () => {
+        resolve(inputStream);
+      });
+    }).on('error', (e) => {
+      reject(e);
+    }).end();
+  });
+};

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
-import { VSCodeGlobals } from './VSCodeGlobals';
-import { ACTIVE_THEME, getCurrentTheme } from './ThemeManager';
-import DokiThemeDefinitions from './DokiThemeDefinitions';
+import {getCurrentTheme} from './ThemeManager';
 
 
 class StatusBar implements vscode.Disposable {
@@ -17,7 +15,7 @@ class StatusBar implements vscode.Disposable {
     }
 
     initialize() {
-        const currentTheme = getCurrentTheme()
+        const currentTheme = getCurrentTheme();
         this.setText(currentTheme.displayName);
     }
 

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { VSCodeGlobals } from './VSCodeGlobals';
-import { ACTIVE_THEME } from './ThemeManager';
+import { ACTIVE_THEME, getCurrentTheme } from './ThemeManager';
+import DokiThemeDefinitions from './DokiThemeDefinitions';
 
 
 class StatusBar implements vscode.Disposable {
@@ -16,10 +17,8 @@ class StatusBar implements vscode.Disposable {
     }
 
     initialize() {
-        const savedTheme: string | undefined = VSCodeGlobals.globalState.get(ACTIVE_THEME);
-        if (savedTheme) {
-            this.setText(savedTheme);
-        }
+        const currentTheme = getCurrentTheme()
+        this.setText(currentTheme.displayName);
     }
 
     dispose() {

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { DokiTheme } from "./DokiTheme";
 import path from 'path';
 import fs from "fs";
-import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus } from "./StickerUpdateService";
+import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus, stickerPathToUrl, cleanPathToUrl } from "./StickerUpdateService";
 import { performGet } from "./RESTClient";
 import { ASSETS_URL, BACKGROUND_ASSETS_URL, VSCODE_ASSETS_URL } from "./ENV";
 
@@ -101,7 +101,7 @@ const downloadSticker = async (stickerPath: string, localDestination: string) =>
 };
 
 const readFileToDataURL = (localStickerPath: string): string => {
-  return `file://${localStickerPath.replace(path.sep, '/')}`;
+  return `file://${cleanPathToUrl(localStickerPath)}`;
 };
 
 export async function getLatestStickerAndBackground(
@@ -115,7 +115,7 @@ export async function getLatestStickerAndBackground(
   if (stickerStatus === StickerUpdateStatus.STALE || 
     !fs.existsSync(localStickerPath) ||
     await isStickerNotCurrent(dokiTheme, localStickerPath)) {
-    await downloadSticker(dokiTheme.sticker.path, localStickerPath);
+    await downloadSticker(stickerPathToUrl(dokiTheme), localStickerPath);
   }
 
   const stickerDataURL = readFileToDataURL(localStickerPath);

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 import { DokiTheme } from "./DokiTheme";
 import path from 'path';
 import fs from "fs";
@@ -36,9 +37,10 @@ function getVsCodeCss() {
   return fs.readFileSync(editorCssCopy, 'utf-8');
 }
 
-function buildStickerCss(dokiTheme: DokiTheme): string {
-  const stickerUrl = dokiTheme.sticker.url;
-  const backgroundImage = dokiTheme.sticker.name;
+function buildStickerCss({
+  stickerDataURL: stickerUrl,
+  backgroundImageURL: backgroundImage
+}: DokiStickers): string {
   const style = 'content:\'\';pointer-events:none;position:absolute;z-index:99999;width:100%;height:100%;background-position:100% 100%;background-repeat:no-repeat;opacity:1;';
   return `
   /* Stickers */
@@ -59,9 +61,9 @@ function buildStickerCss(dokiTheme: DokiTheme): string {
 `;
 }
 
-function buildStyles(dokiTheme: DokiTheme): string {
+function buildStyles(dokiStickers: DokiStickers): string {
   let vsCodeCss = getVsCodeCss();
-  return vsCodeCss + buildStickerCss(dokiTheme);
+  return vsCodeCss + buildStickerCss(dokiStickers);
 
 }
 function installEditorStyles(styles: string) {
@@ -77,9 +79,31 @@ function canWrite(): boolean {
   }
 }
 
-export function installSticker(dokiTheme: DokiTheme): boolean {
+export interface DokiStickers {
+  stickerDataURL: string;
+  backgroundImageURL: string;
+}
+
+export function getLatestStickerAndBackground(
+  dokiTheme: DokiTheme,
+  context: vscode.ExtensionContext,
+  ): DokiStickers {
+    return {
+      stickerDataURL: dokiTheme.sticker.url,
+      backgroundImageURL: dokiTheme.sticker.name
+    }
+}
+
+export function installSticker(
+  dokiTheme: DokiTheme,
+  context: vscode.ExtensionContext,
+  ): boolean {
   if (canWrite()) {
-    const stickerStyles = buildStyles(dokiTheme);
+    const stickersAndBackground = getLatestStickerAndBackground(
+      dokiTheme,
+      context
+    );
+    const stickerStyles = buildStyles(stickersAndBackground);
     installEditorStyles(stickerStyles);
     return true;
   } else {

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { DokiTheme } from "./DokiTheme";
 import path from 'path';
 import fs from "fs";
-import { resolveLocalStickerPath, isStickerCurrent, buildRemoteStickerPath, StickerUpdateStatus } from "./StickerUpdateService";
+import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus } from "./StickerUpdateService";
 import { performGet } from "./RESTClient";
 import { ASSETS_URL, BACKGROUND_ASSETS_URL, VSCODE_ASSETS_URL } from "./ENV";
 
@@ -114,7 +114,7 @@ export async function getLatestStickerAndBackground(
   );
   if (stickerStatus === StickerUpdateStatus.STALE || 
     !fs.existsSync(localStickerPath) ||
-    !(await isStickerCurrent(dokiTheme, localStickerPath))) {
+    await isStickerNotCurrent(dokiTheme, localStickerPath)) {
     await downloadSticker(dokiTheme.sticker.path, localStickerPath);
   }
 

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -96,12 +96,12 @@ const downloadSticker = async (stickerPath: string, localDestination: string) =>
   const stickerUrl = `${VSCODE_ASSETS_URL}${stickerPath}`;
   console.log(`Downloading image: ${stickerUrl}`);
   const stickerInputStream = await performGet(stickerUrl);
+  console.log('Image Downloaded!');
   fs.writeFileSync(localDestination, stickerInputStream.read());
 };
 
 const readFileToDataURL = (localStickerPath: string): string => {
-  const base64ImageString = fs.readFileSync(localStickerPath, {encoding: 'base64'});
-  return `data:image/png;base64,${base64ImageString}`;
+  return `file://${localStickerPath.replace(path.sep, '/')}`;
 };
 
 export async function getLatestStickerAndBackground(

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -91,7 +91,7 @@ export function getLatestStickerAndBackground(
     return {
       stickerDataURL: dokiTheme.sticker.url,
       backgroundImageURL: dokiTheme.sticker.name
-    }
+    };
 }
 
 export function installSticker(

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -13,15 +13,19 @@ export enum InstallStatus {
 const main = require.main || { filename: 'yeet' };
 export const workbenchDirectory = path.join(path.dirname(main.filename), 'vs', 'workbench');
 
+const CODE_SERVER_FILE = 'web.api';
 const getFileName = () => {
   return fs.existsSync(path.join(workbenchDirectory, `workbench.desktop.main.css`)) ?
-    'desktop.main' : 'web.api';
+    'desktop.main' : CODE_SERVER_FILE;
 };
 
 const fileName = getFileName();
 
 const editorCss = path.join(workbenchDirectory, `workbench.${fileName}.css`);
 const editorCssCopy = path.join(workbenchDirectory, `workbench.${fileName}.css.copy`);
+
+
+const isCodeServer = () => fileName === CODE_SERVER_FILE;
 
 // Was VS Code upgraded when stickers where installed?
 function isCssPrestine() {
@@ -101,6 +105,11 @@ const downloadSticker = async (stickerPath: string, localDestination: string) =>
 };
 
 const readFileToDataURL = (localStickerPath: string): string => {
+  if(isCodeServer()) {
+    const base64ImageString = fs.readFileSync(localStickerPath, {encoding: 'base64'});
+    return `data:image/png;base64,${base64ImageString}`; 
+  }
+  
   return `file://${cleanPathToUrl(localStickerPath)}`;
 };
 
@@ -119,6 +128,7 @@ export async function getLatestStickerAndBackground(
   }
 
   const stickerDataURL = readFileToDataURL(localStickerPath);
+
   return {
     stickerDataURL,
     backgroundImageURL: dokiTheme.sticker.name

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -89,7 +89,7 @@ export function getLatestStickerAndBackground(
   context: vscode.ExtensionContext,
   ): DokiStickers {
     return {
-      stickerDataURL: dokiTheme.sticker.url,
+      stickerDataURL: dokiTheme.sticker.path,
       backgroundImageURL: dokiTheme.sticker.name
     };
 }

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -3,5 +3,5 @@ import { getCurrentTheme } from './ThemeManager';
 
 export const attemptToUpdateSticker = (context: vscode.ExtensionContext) => {
   const currentTheme = getCurrentTheme();
-  console.log(currentTheme.name);
+  console.log(currentTheme.name, context.globalStoragePath);
 };

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 import { VSCODE_ASSETS_URL } from './ENV';
 
 const fetchRemoteChecksum = async (currentTheme: DokiTheme) => {
-  const checksumUrl = `${VSCODE_ASSETS_URL}${currentTheme.sticker.path}.checksum.txt`;
+  const checksumUrl = `${VSCODE_ASSETS_URL}${stickerPathToUrl(currentTheme)}.checksum.txt`;
   console.log(`Fetching checksum: ${checksumUrl}`);
   const checkSumInputStream = await performGet(checksumUrl);
   return checkSumInputStream.setEncoding('utf8').read();
@@ -19,9 +19,18 @@ export const resolveLocalStickerPath = (
   currentTheme: DokiTheme,
   context: vscode.ExtensionContext,
 ): string => {
-  const safeStickerPath = currentTheme.sticker.path.replace('/', path.sep);
+  const safeStickerPath = stickerPathToUrl(currentTheme);
   return path.join(context.globalStoragePath, 'stickers', safeStickerPath);
 };
+
+export function cleanPathToUrl(stickerPath: string) {
+  return stickerPath.replace(/\\/g, '/');
+}
+
+export function stickerPathToUrl(currentTheme: DokiTheme) {
+  const stickerPath = currentTheme.sticker.path;
+  return cleanPathToUrl(stickerPath);
+}
 
 export function createChecksum(data: Buffer | string): string {
   return crypto.createHash('md5')

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -1,14 +1,31 @@
 import * as vscode from 'vscode';
 import { getCurrentTheme } from './ThemeManager';
 import { performGet } from './RESTClient';
+import { installSticker } from './StickerService';
+import { DokiTheme } from './DokiTheme';
 
-export const attemptToUpdateSticker = (context: vscode.ExtensionContext) => {
+const fetchRemoteChecksum = async (currentTheme: DokiTheme) => {
+  const checkSumInputStream = await performGet('https://doki.assets.acari.io/stickers/vscode/reZero/rem/rem.png.checksum.txt');
+  return checkSumInputStream.setEncoding('utf8').read();
+};
+
+const fetchLocalChecksum = async (currentTheme: DokiTheme) => {
+  return 'yeet!';  
+};
+
+export const attemptToUpdateSticker = async (context: vscode.ExtensionContext) => {
   const currentTheme = getCurrentTheme();
   console.log(currentTheme.name, context.globalStoragePath);
-  performGet('https://doki.assets.acari.io/stickers/vscode/reZero/rem/rem.png.checksum.txt').then(result => {
-    console.log('I got this thing', result.setEncoding('utf8').read());
-  }).catch(er => {
-    console.log("Oh shit this", er);
-    
-  });
+
+  try {
+    const remoteChecksum = await fetchRemoteChecksum(currentTheme);
+    const localChecksum = await fetchLocalChecksum(currentTheme);
+    if(remoteChecksum !== localChecksum) {
+      console.log('sticker is different');
+      
+      // installSticker(currentTheme, context);
+    }    
+  } catch(e) {
+    console.error('Unable to check for updates', e);
+  }
 };

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -20,7 +20,7 @@ export const resolveLocalStickerPath = (
   context: vscode.ExtensionContext,
 ): string => {
   const safeStickerPath = currentTheme.sticker.path.replace('/', path.sep);
-  return path.join(context.globalStoragePath, safeStickerPath);
+  return path.join(context.globalStoragePath, 'stickers', safeStickerPath);
 };
 
 export function createChecksum(data: Buffer | string): string {
@@ -35,7 +35,8 @@ const calculateFileChecksum = (filePath: string): string => {
 };
 
 const fetchLocalChecksum = async (localSticker: string) => {
-  return fs.existsSync(localSticker) ? calculateFileChecksum(localSticker) : 'File not downloaded, bruv.';
+  return fs.existsSync(localSticker) ?
+    calculateFileChecksum(localSticker) : 'File not downloaded, bruv.';
 };
 
 export const isStickerNotCurrent = async (
@@ -52,7 +53,7 @@ export const isStickerNotCurrent = async (
   }
 };
 export enum StickerUpdateStatus {
-  CURRENT, STALE, NOT_CHECKED, 
+  CURRENT, STALE, NOT_CHECKED,
 }
 
 export const attemptToUpdateSticker = async (context: vscode.ExtensionContext) => {

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+import { getCurrentTheme } from './ThemeManager';
+
+export const attemptToUpdateSticker = (context: vscode.ExtensionContext) => {
+  const currentTheme = getCurrentTheme();
+  console.log(currentTheme.name);
+};

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -38,7 +38,7 @@ const fetchLocalChecksum = async (localSticker: string) => {
   return fs.existsSync(localSticker) ? calculateFileChecksum(localSticker) : 'File not downloaded, bruv.';
 };
 
-export const isStickerCurrent = async (
+export const isStickerNotCurrent = async (
   dokiTheme: DokiTheme,
   localStickerPath: string
 ): Promise<boolean> => {
@@ -58,7 +58,7 @@ export enum StickerUpdateStatus {
 export const attemptToUpdateSticker = async (context: vscode.ExtensionContext) => {
   const currentTheme = getCurrentTheme();
   const localStickerPath = resolveLocalStickerPath(currentTheme, context);
-  if (await isStickerCurrent(currentTheme, localStickerPath)) {
+  if (await isStickerNotCurrent(currentTheme, localStickerPath)) {
     await installSticker(currentTheme, context, StickerUpdateStatus.STALE);
   }
 };

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -3,23 +3,46 @@ import { getCurrentTheme } from './ThemeManager';
 import { performGet } from './RESTClient';
 import { installSticker } from './StickerService';
 import { DokiTheme } from './DokiTheme';
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
 
 const fetchRemoteChecksum = async (currentTheme: DokiTheme) => {
   const checkSumInputStream = await performGet('https://doki.assets.acari.io/stickers/vscode/reZero/rem/rem.png.checksum.txt');
   return checkSumInputStream.setEncoding('utf8').read();
 };
 
-const fetchLocalChecksum = async (currentTheme: DokiTheme) => {
-  return 'yeet!';  
+export const resolveLocalStickerPath = (
+  currentTheme: DokiTheme,
+  context: vscode.ExtensionContext,
+): string => {
+  const safeStickerPath = currentTheme.sticker.path.replace('/', path.sep);
+  return path.join(context.globalStoragePath, safeStickerPath);
+};
+
+export function createChecksum(data: Buffer | string): string {
+  return crypto.createHash('md5')
+    .update(data)
+    .digest('hex');
+}
+
+const calculateFileChecksum = (filePath: string): string => {
+  const fileRead = fs.readFileSync(filePath);
+  return createChecksum(fileRead);
+};
+
+const fetchLocalChecksum = async (currentTheme: DokiTheme, context: vscode.ExtensionContext) => {
+  const localSticker = resolveLocalStickerPath(currentTheme, context);
+  return fs.existsSync(localSticker) ? calculateFileChecksum(localSticker) : 'Not a checksum, bruv.';  
 };
 
 export const attemptToUpdateSticker = async (context: vscode.ExtensionContext) => {
-  const currentTheme = getCurrentTheme();
-  console.log(currentTheme.name, context.globalStoragePath);
-
+  const currentTheme = getCurrentTheme();  
   try {
     const remoteChecksum = await fetchRemoteChecksum(currentTheme);
-    const localChecksum = await fetchLocalChecksum(currentTheme);
+    const localChecksum = await fetchLocalChecksum(currentTheme, context);
+    console.log(remoteChecksum, localChecksum);
+    
     if(remoteChecksum !== localChecksum) {
       console.log('sticker is different');
       

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -1,7 +1,14 @@
 import * as vscode from 'vscode';
 import { getCurrentTheme } from './ThemeManager';
+import { performGet } from './RESTClient';
 
 export const attemptToUpdateSticker = (context: vscode.ExtensionContext) => {
   const currentTheme = getCurrentTheme();
   console.log(currentTheme.name, context.globalStoragePath);
+  performGet('https://doki.assets.acari.io/stickers/vscode/reZero/rem/rem.png.checksum.txt').then(result => {
+    console.log('I got this thing', result.setEncoding('utf8').read());
+  }).catch(er => {
+    console.log("Oh shit this", er);
+    
+  });
 };

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -76,7 +76,10 @@ export function uninstallImages(
 export const getCurrentTheme = (): DokiTheme => {
   const currentThemeId = VSCodeGlobals.globalState.get(ACTIVE_THEME);
   const dokiThemeDefinition = DokiThemeDefinitions.find(
-    dokiDefinition => dokiDefinition.themeDefinition.information.id === currentThemeId
+    dokiDefinition => 
+    dokiDefinition.themeDefinition.information.id === currentThemeId ||
+    // todo: remove this after deploy.
+    dokiDefinition.themeDefinition.information.displayName == currentThemeId
   ) || DokiThemeDefinitions[0];
   return new DokiTheme(dokiThemeDefinition.themeDefinition);
 };

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -4,6 +4,7 @@ import { installSticker, removeStickers, InstallStatus } from "./StickerService"
 import { VSCodeGlobals } from "./VSCodeGlobals";
 import { StatusBarComponent } from "./StatusBar";
 import { showStickerInstallationSupportWindow, showStickerRemovalSupportWindow } from "./SupportService";
+import DokiThemeDefinitions from "./DokiThemeDefinitions";
 
 export const ACTIVE_THEME = 'doki.theme.active';
 
@@ -49,7 +50,7 @@ export function activateTheme(
 ) {
   attemptToInstall(dokiTheme, context).then(didInstall => {
     if (didInstall === InstallStatus.INSTALLED) {
-      VSCodeGlobals.globalState.update(ACTIVE_THEME, dokiTheme.displayName);
+      VSCodeGlobals.globalState.update(ACTIVE_THEME, dokiTheme.id);
       StatusBarComponent.setText(dokiTheme.displayName);
       vscode.window.showInformationMessage(`${dokiTheme.name} installed!\n Please restart your IDE`);
     } else if (didInstall === InstallStatus.FAILURE) {
@@ -72,3 +73,11 @@ export function uninstallImages(
     vscode.window.showErrorMessage(`Unable to remove stickers/background, please see active tab for more information.`);
   }
 }
+
+export const getCurrentTheme = (): DokiTheme => {
+  const currentThemeId = VSCodeGlobals.globalState.get(ACTIVE_THEME);
+  const dokiThemeDefinition = DokiThemeDefinitions.find(
+    dokiDefinition => dokiDefinition.themeDefinition.information.id === currentThemeId
+  ) || DokiThemeDefinitions[0]
+  return new DokiTheme(dokiThemeDefinition.themeDefinition);
+};

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -27,18 +27,18 @@ async function attemptToInstall(
 
     if (result && result.title === stickerInstall) {
       context.globalState.update(FIRST_TIME_STICKER_INSTALL, true);
-      const installStatus = performStickerInstall(dokiTheme);
+      const installStatus = performStickerInstall(dokiTheme, context);
       return installStatus;
     } else {
       return InstallStatus.NOT_INSTALLED;
     }
   } else {
-    return performStickerInstall(dokiTheme);
+    return performStickerInstall(dokiTheme, context);
   }
 }
 
-function performStickerInstall(dokiTheme: DokiTheme) {
-  const installResult = installSticker(dokiTheme);
+function performStickerInstall(dokiTheme: DokiTheme, context: vscode.ExtensionContext) {
+  const installResult = installSticker(dokiTheme, context);
   return installResult ? InstallStatus.INSTALLED :
     InstallStatus.FAILURE;
 }

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -1,9 +1,9 @@
 import * as vscode from "vscode";
-import { DokiTheme } from "./DokiTheme";
-import { installSticker, removeStickers, InstallStatus } from "./StickerService";
-import { VSCodeGlobals } from "./VSCodeGlobals";
-import { StatusBarComponent } from "./StatusBar";
-import { showStickerInstallationSupportWindow, showStickerRemovalSupportWindow } from "./SupportService";
+import {DokiTheme} from "./DokiTheme";
+import {InstallStatus, installSticker, removeStickers} from "./StickerService";
+import {VSCodeGlobals} from "./VSCodeGlobals";
+import {StatusBarComponent} from "./StatusBar";
+import {showStickerInstallationSupportWindow, showStickerRemovalSupportWindow} from "./SupportService";
 import DokiThemeDefinitions from "./DokiThemeDefinitions";
 
 export const ACTIVE_THEME = 'doki.theme.active';
@@ -28,8 +28,7 @@ async function attemptToInstall(
 
     if (result && result.title === stickerInstall) {
       context.globalState.update(FIRST_TIME_STICKER_INSTALL, true);
-      const installStatus = performStickerInstall(dokiTheme, context);
-      return installStatus;
+      return performStickerInstall(dokiTheme, context);
     } else {
       return InstallStatus.NOT_INSTALLED;
     }
@@ -78,6 +77,6 @@ export const getCurrentTheme = (): DokiTheme => {
   const currentThemeId = VSCodeGlobals.globalState.get(ACTIVE_THEME);
   const dokiThemeDefinition = DokiThemeDefinitions.find(
     dokiDefinition => dokiDefinition.themeDefinition.information.id === currentThemeId
-  ) || DokiThemeDefinitions[0]
+  ) || DokiThemeDefinitions[0];
   return new DokiTheme(dokiThemeDefinition.themeDefinition);
 };

--- a/src/WelcomeService.ts
+++ b/src/WelcomeService.ts
@@ -1,6 +1,7 @@
 import { VSCodeGlobals } from "./VSCodeGlobals";
 import * as vscode from 'vscode';
 import { getWebviewIcon, buildWebviewHtml } from "./ChangelogService";
+import { SCREENSHOT_ASSETS_URL } from "./ENV";
 
 const IS_GREETED = 'doki.theme.greeted';
 
@@ -67,7 +68,7 @@ export function attemptToGreetUser(context: vscode.ExtensionContext) {
                <h2>Sample Usage</h2>
                 <img 
                 style="z-index: 9001;"
-                src="https://doki.assets.unthrottled.io/screenshots/doki-theme-vscode-usage.gif" alt="Theme Usage"/>
+                src="${SCREENSHOT_ASSETS_URL}/doki-theme-vscode-usage.gif" alt="Theme Usage"/>
                 Steps Demonstrated:
                 <ol>
                     <li>Choose Color Theme</li>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { StatusBarComponent } from './StatusBar';
 import { VSCodeGlobals } from './VSCodeGlobals';
 import { attemptToNotifyUpdates } from './NotificationService';
 import { showChanglog } from './ChangelogService';
+import { attemptToUpdateSticker } from './StickerUpdateService';
 
 export interface DokiThemeDefinition {
 	sticker: {
@@ -42,6 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(StatusBarComponent);
 
 	attemptToNotifyUpdates(context);
+	
+	attemptToUpdateSticker(context);
 
 	DokiThemeDefinitions
 		.map((dokiThemeDefinition: VSCodeDokiThemeDefinition) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,8 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	attemptToUpdateSticker(context);
 
+
+
 	DokiThemeDefinitions
 		.map((dokiThemeDefinition: VSCodeDokiThemeDefinition) =>
 			vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,8 +46,6 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	attemptToUpdateSticker(context);
 
-
-
 	DokiThemeDefinitions
 		.map((dokiThemeDefinition: VSCodeDokiThemeDefinition) =>
 			vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { attemptToUpdateSticker } from './StickerUpdateService';
 
 export interface DokiThemeDefinition {
 	sticker: {
-		url: string;
+		path: string;
 		name: string;
 	};
 	information: any;


### PR DESCRIPTION

#### Description
<!-- Describe your changes in detail -->
Wiring the plugin into my assets infrastructure.
Plugin checks to see if the current sticker being used is the most up to date.
If the sticker is not the same in the infrastructure, then it downloads and sets that as the current used sticker.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Right now all of the stickers are drawn in all different styles, I eventually want to migrate them to look roughly like this style:

Just Monika            |  Natsuki | Mioda Ibuki
:-------------------------:|:-------------------------:|:-------------------------:
![Just Monika](https://doki.assets.unthrottled.io/stickers/vscode/literature/monika/light/just_monika.png) | ![natsuki](https://doki.assets.unthrottled.io/stickers/vscode/literature/natsuki/light/natsuki.png) | ![image](https://doki.assets.unthrottled.io/stickers/vscode/danganronpa/ibuki/light/ibuki_light.png)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
It works offline if you have already downloaded the sticker.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.