### PR TITLE
Sticker removal fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.4.1 [Sticker Removal Fix]
+
+- Fixed the issue with the sticker not being removed after installing multiple stickers.
+
 ## 2.4.0 [Secondary Sticker Port]
 
 - Brought the secondary stickers from the Intellij themes over to VSCode!

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "Themes based on various anime and visual novel characters.",
   "publisher": "unthrottled",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from './VSCodeGlobals';
 import { attemptToGreetUser } from './WelcomeService';
 
 const SAVED_VERSION = 'doki.theme.version';
-const DOKI_THEME_VERSION = 'v2.4.0';
+const DOKI_THEME_VERSION = 'v2.4.1';
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
     const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Checks the CSS for sticker changes based off comments rather than the `https://doki.assets.unthrottled.io/` assets url that went away when I installed the stickers locally.....

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #14 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->

Steps to reproduce bug:
1. Install a Sticker
1. Reload VSCode
1. Install some other sticker
1. Reload VSCode
1. Run `Remove Sticker` command

Your VS Code will now be in a state where you have your first sticker installed and it will remain that way.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.